### PR TITLE
New slack version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,24 +18,24 @@
   "author": "Rodney Lorrimar",
   "license": "ISC",
   "dependencies": {
-    "@slack/web-api": "^6.1.0",
-    "axios": "^0.21.1"
+    "@slack/web-api": "^6.9.0",
+    "axios": "^1.4.0"
   },
   "devDependencies": {
-    "@types/chrome": "0.0.100",
-    "@types/jquery": "^3.3.33",
-    "copy-webpack-plugin": "^6.1.0",
-    "glob": "^7.1.6",
-    "prettier": "^2.2.1",
-    "rimraf": "^3.0.2 ",
-    "ts-jest": "^25.2.1 ",
-    "ts-loader": "^6.2.1",
-    "typescript": "~3.8.3 ",
-    "web-ext": "^6.2.0",
+    "@types/chrome": "0.0.243",
+    "@types/jquery": "^3.5.16",
+    "copy-webpack-plugin": "^11.0.0",
+    "glob": "^10.3.3",
+    "prettier": "^3.0.1",
+    "rimraf": "^5.0.1",
+    "ts-jest": "^29.1.1",
+    "ts-loader": "^9.4.4",
+    "typescript": "~5.1.6",
+    "web-ext": "^4.0.0",
     "webextension-polyfill-ts": "^0.26.0",
-    "webpack": "^4.44.1",
-    "webpack-cli": "~3.3.11",
-    "webpack-merge": "~4.2.2"
+    "webpack": "^5.88.2",
+    "webpack-cli": "~5.1.4",
+    "webpack-merge": "~5.9.0"
   },
   "webExt": {
     "sourceDir": "dist/firefox/",
@@ -44,7 +44,9 @@
       "overwriteDest": true
     },
     "run": {
-      "startUrl": ["https://app.slack.com"],
+      "startUrl": [
+        "https://app.slack.com"
+      ],
       "browserConsole": true
     }
   }

--- a/public/content.css
+++ b/public/content.css
@@ -1,14 +1,11 @@
-button[aria-label="Save for later"],
-button[aria-label="Remove from Later"] {
-  /* background-color: red; */
-  background-image: url("images/org-capture-slack48");
+[aria-label="Save for later"] > svg,
+[aria-label="Remove from Later"] > svg {
+  display: none;
 }
 
-button[aria-label="Save for later"] > svg,
-button[aria-label="Remove from Later"] > svg {
+[aria-label="Save for later"]::after,
+[aria-label="Remove from Later"]::after {
   content: "\1F984" !important;
-  /* background-image: url(http://moodle.org/mod/glossary/icon.gif); */
-  /* background-image: url("images/org-capture-slack48"); */
 }
 
 /* remove the desktop notifications warning */

--- a/public/content.css
+++ b/public/content.css
@@ -1,11 +1,14 @@
-button[aria-label="Add to saved items"],
-button[aria-label="Remove from saved items"] {
+button[aria-label="Save for later"],
+button[aria-label="Remove from Later"] {
   /* background-color: red; */
+  background-image: url("images/org-capture-slack48");
 }
 
-button[aria-label="Add to saved items"] > .c-icon:before,
-button[aria-label="Remove from saved items"] > .c-icon:before {
+button[aria-label="Save for later"] > svg,
+button[aria-label="Remove from Later"] > svg {
   content: "\1F984" !important;
+  /* background-image: url(http://moodle.org/mod/glossary/icon.gif); */
+  /* background-image: url("images/org-capture-slack48"); */
 }
 
 /* remove the desktop notifications warning */

--- a/src/content_capture_button.ts
+++ b/src/content_capture_button.ts
@@ -40,7 +40,7 @@ function isOurButton(el: HTMLButtonElement) {
 document.addEventListener("click", e => {
   for (let target = e.target; target && target !== document; target = (target as Element).parentNode) {
     // console.log("slack body clicked - target", target);
-    const button = target as HTMLButtonElement
+    const button = target as HTMLButtonElement;
     if (isOurButton(button)) {
       console.log("it's ours, with dataset", button.dataset);
       const meta = button.dataset.focusMetadata ? JSON.parse(button.dataset.focusMetadata) : undefined;

--- a/src/content_capture_button.ts
+++ b/src/content_capture_button.ts
@@ -34,7 +34,7 @@ port.onMessage.addListener(request => {
 function isOurButton(el: HTMLButtonElement) {
   const label = el.getAttribute("aria-label");
   return el.type === "button" &&
-    (label === "Add to saved items" || label === "Remove from saved items");
+    (label === "Save for later" || label === "Remove from Later");
 }
 
 document.addEventListener("click", e => {

--- a/src/fetchSlack.ts
+++ b/src/fetchSlack.ts
@@ -10,9 +10,9 @@ export async function fetchMessageInfo(captureMetadata: CaptureMetadata, token: 
   });
 
   const [msg, permalink, channel] = await Promise.all([
-    fetchMessage(client, captureMetadata.channelId, captureMetadata.ts),
-    fetchPermalink(client, captureMetadata.channelId, captureMetadata.ts),
-    fetchChannelName(client, captureMetadata.channelId),
+    fetchMessage(client, captureMetadata.id, captureMetadata.uiState.ts),
+    fetchPermalink(client, captureMetadata.id, captureMetadata.uiState.ts),
+    fetchChannelName(client, captureMetadata.id),
   ]);
   const username = await fetchUsername(client, msg.user);
   return {
@@ -20,7 +20,7 @@ export async function fetchMessageInfo(captureMetadata: CaptureMetadata, token: 
     channel,
     content: msg.text,
     author: username,
-    date: tsToTime(captureMetadata.ts),
+    date: tsToTime(captureMetadata.uiState.ts),
   };
 }
 
@@ -46,9 +46,10 @@ interface Message {
 }
 
 async function fetchMessage(client: AxiosInstance, channel: string, ts: string): Promise<Message> {
-  const result = await client.get("conversations.history", {
+  const result = await client.get("conversations.replies", {
     params: {
       channel,
+      ts: ts,
       latest: ts,
       inclusive: true,
       limit: 1,

--- a/src/orgProtocol.ts
+++ b/src/orgProtocol.ts
@@ -9,8 +9,8 @@ export function makeMessageURL(meta: CaptureMetadata): string {
   // example:
   // https://rvl-test.slack.com/archives/CLEHCKMQW/p1616409584000200
   // {button: "save", channelId: "CLEHCKMQW", ts: "1616409584.000200", messageContainerType: "message-pane"}
-  const msg = "p" + meta.ts.replace(".", "");
-  return `${location.protocol}//${location.hostname}/archives/${meta.channelId}/${msg}`;
+  const msg = "p" + meta.uiState.ts.replace(".", "");
+  return `${location.protocol}//${location.hostname}/archives/${meta.id}/${msg}`;
 }
 
 export function orgProtocolURI(params: { [key: string]: string }): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,10 @@
 // {button: "save", channelId: "CLEHCKMQW", ts: "1616409584.000200", messageContainerType: "message-pane"}
+// {id: "CLEHCKMQW", params: { messageContainerType: "Channel" }, uiState: { ts: "1689705262.534379", button: "later" }
 export interface CaptureMetadata {
-  channelId: string;
-  ts: string;
+  id: string;
+  uiState: {
+    ts: string;
+  };
 }
 
 export interface MessageInfo {

--- a/webpack/webpack.configs.js
+++ b/webpack/webpack.configs.js
@@ -2,7 +2,7 @@ const webpack = require("webpack");
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 const _ = require("lodash");
-const webpackMerge = require('webpack-merge');
+const { merge: webpackMerge } = require('webpack-merge');
 
 const srcDir = path.join(__dirname, "..", "src");
 const distDir = path.join(__dirname, "..", "dist");


### PR DESCRIPTION
Sun 13 Aug 2023 10:36:24 BST

Update to allow this package to work with a newer version of Slack (changed after 2023-03-30, last time `org-capture-slack` worked for me).

Major changes:
1. Button labels 
2. captureMetadata field names
3. Original bookmark `aria-icon` has been changed to a (classless) svg image.


